### PR TITLE
Include all timezone abbreviations

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -48,7 +48,7 @@ function decorateEditor(editor) {
 
     const text = editor.document.getText();
     const decorations = [];
-    const timestampRegex = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC/;
+    const timestampRegex = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \b[A-Z]{2,5}\b/;
 
     let lineNumber;
 


### PR DESCRIPTION
Hello,

Due to the following [regex](https://github.com/ccdaniele/ddpaths/blob/9810fad27fc7c3fa0be6c8d8fb8d7a8a89c44101/extension.js#L51), there can be an issue in case the timezone of the log messages are not in `UTC` :

`2024-12-11 01:21:09 CST | CORE | INFO | (pkg/collector/scheduler/scheduler.go:91 in Enter) | Scheduling check uptime with an interval of 15s
`

This fixes that by taking into account [all timezone abbreviations](https://en.wikipedia.org/wiki/List_of_time_zone_abbreviations).